### PR TITLE
Replace credit card edit icon with lucide Edit2

### DIFF
--- a/src/app/entity-module/organisation/tabs/students/page.tsx
+++ b/src/app/entity-module/organisation/tabs/students/page.tsx
@@ -24,7 +24,7 @@
 'use client';
 
 import React, { useState, useMemo } from 'react';
-import { GraduationCap, Users, BookOpen, Award, Clock, Plus, Search, Filter, Calendar, FileText, Heart, DollarSign, Bus, Shield, Info, AlertTriangle, CheckCircle2, XCircle, Loader2, BarChart3, UserCheck, Settings, MapPin, Phone, Mail, Home, CreditCard, CreditCard as Edit2, Eye, MoreVertical, User } from 'lucide-react';
+import { GraduationCap, Users, BookOpen, Award, Clock, Plus, Search, Filter, Calendar, FileText, Heart, DollarSign, Bus, Shield, Info, AlertTriangle, CheckCircle2, XCircle, Loader2, BarChart3, UserCheck, Settings, MapPin, Phone, Mail, Home, CreditCard, Edit2, Eye, MoreVertical, User } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../../../../../lib/supabase';
 import { useAccessControl } from '../../../../../hooks/useAccessControl';

--- a/src/app/entity-module/organisation/tabs/teachers/page.tsx
+++ b/src/app/entity-module/organisation/tabs/teachers/page.tsx
@@ -16,7 +16,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { Users, Award, Calendar, BookOpen, Clock, Briefcase, Plus, Search, Filter, AlertTriangle, Info, CheckCircle2, Loader2, UserCheck, GraduationCap, CreditCard as Edit2, Eye, MoreVertical, Mail, Phone, MapPin, Download, Upload, Key, Copy, RefreshCw, Trash2, UserX, FileText, ChevronDown, X, User, Building2, School, Grid3x3, Layers, Shield, Hash, EyeOff, CheckCircle, XCircle, Send, Link2, BookOpenCheck, Award as AwardIcon, ChevronRight, ChevronLeft, Check, ArrowRight } from 'lucide-react';
+import { Users, Award, Calendar, BookOpen, Clock, Briefcase, Plus, Search, Filter, AlertTriangle, Info, CheckCircle2, Loader2, UserCheck, GraduationCap, Edit2, Eye, MoreVertical, Mail, Phone, MapPin, Download, Upload, Key, Copy, RefreshCw, Trash2, UserX, FileText, ChevronDown, X, User, Building2, School, Grid3x3, Layers, Shield, Hash, EyeOff, CheckCircle, XCircle, Send, Link2, BookOpenCheck, Award as AwardIcon, ChevronRight, ChevronLeft, Check, ArrowRight } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../../../../../lib/supabase';
 import { useUser } from '../../../../../contexts/UserContext';

--- a/src/components/shared/ActionButtons.tsx
+++ b/src/components/shared/ActionButtons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Eye, CreditCard as Edit, Trash2, MoreVertical } from 'lucide-react';
+import { Eye, Edit2, Trash2 } from 'lucide-react';
 
 interface ActionButtonsProps {
   onView?: () => void;
@@ -48,7 +48,7 @@ export function ActionButtons({
           title="Edit"
           aria-label="Edit"
         >
-          <Edit className="w-4 h-4" />
+          <Edit2 className="w-4 h-4" />
         </button>
       )}
 

--- a/src/components/shared/CardListView.tsx
+++ b/src/components/shared/CardListView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, ReactNode } from 'react';
-import { Grid3x3, List, Eye, CreditCard as Edit, Trash2 } from 'lucide-react';
+import { Grid3x3, List, Eye, Edit2, Trash2 } from 'lucide-react';
 import { StatusBadge } from './StatusBadge';
 import { ActionButtons } from './ActionButtons';
 import { DataTable } from './DataTable';


### PR DESCRIPTION
## Summary
- update shared action and card list components to render the lucide Edit2 icon instead of an aliased CreditCard
- align organisation teachers and students tabs with the shared Edit2 icon so edit affordances stay consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc532edca0832dba0a57674c1bed3d