### PR TITLE
Use shared tabs component for students view

### DIFF
--- a/src/app/entity-module/organisation/tabs/students/page.tsx
+++ b/src/app/entity-module/organisation/tabs/students/page.tsx
@@ -34,6 +34,7 @@ import { FormField, Input, Select } from '../../../../../components/shared/FormF
 import { StatusBadge } from '../../../../../components/shared/StatusBadge';
 import { toast } from '../../../../../components/shared/Toast';
 import StudentForm from '../../../../../components/forms/StudentForm';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/shared/Tabs';
 
 // Student data interface
 interface StudentData {
@@ -66,6 +67,8 @@ export interface StudentsTabProps {
   refreshData?: () => void;
 }
 
+type StudentsTabKey = 'overview' | 'list' | 'analytics';
+
 export default function StudentsTab({ companyId, refreshData }: StudentsTabProps) {
   const { user } = useUser();
   const {
@@ -83,7 +86,7 @@ export default function StudentsTab({ companyId, refreshData }: StudentsTabProps
   } = useAccessControl();
 
   // Local state
-  const [activeTab, setActiveTab] = useState<'overview' | 'list' | 'analytics'>('overview');
+  const [activeTab, setActiveTab] = useState<StudentsTabKey>('overview');
   const [searchTerm, setSearchTerm] = useState('');
   const [filterGrade, setFilterGrade] = useState<string>('all');
   const [filterSchool, setFilterSchool] = useState<string>('all');
@@ -91,6 +94,12 @@ export default function StudentsTab({ companyId, refreshData }: StudentsTabProps
   const [selectedStudents, setSelectedStudents] = useState<string[]>([]);
   const [showStudentForm, setShowStudentForm] = useState(false);
   const [editingStudent, setEditingStudent] = useState<StudentData | null>(null);
+
+  const handleTabChange = (value: string) => {
+    if (value === 'overview' || value === 'list' || value === 'analytics') {
+      setActiveTab(value);
+    }
+  };
 
   // PHASE 5 RULE 1: ACCESS CHECK
   React.useEffect(() => {
@@ -573,421 +582,362 @@ export default function StudentsTab({ companyId, refreshData }: StudentsTabProps
           </div>
         </div>
 
-        {/* Tab Navigation */}
-        <div className="flex space-x-1 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg mb-6">
-          <button
-            onClick={() => setActiveTab('overview')}
-            className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'overview'
-                ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm'
-                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
-            }`}
-          >
-            <Award className="w-4 h-4 inline mr-2" />
-            Overview
-          </button>
-          <button
-            onClick={() => setActiveTab('list')}
-            className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'list'
-                ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm'
-                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
-            }`}
-          >
-            <Users className="w-4 h-4 inline mr-2" />
-            Student List
-          </button>
-          <button
-            onClick={() => setActiveTab('analytics')}
-            className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'analytics'
-                ? 'bg-white dark:bg-gray-800 text-gray-900 dark:text-white shadow-sm'
-                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
-            }`}
-          >
-            <BarChart3 className="w-4 h-4 inline mr-2" />
-            Analytics
-          </button>
-        </div>
-      </div>
+        <Tabs
+          defaultValue="overview"
+          value={activeTab}
+          onValueChange={handleTabChange}
+          className="w-full"
+        >
+          {/* Tab Navigation */}
+          <TabsList className="w-full justify-between gap-1 bg-gray-100 dark:bg-gray-700 p-1 rounded-lg mb-4">
+            <TabsTrigger value="overview" className="flex-1">
+              <span className="flex items-center justify-center gap-2">
+                <Award className="w-4 h-4" />
+                Overview
+              </span>
+            </TabsTrigger>
+            <TabsTrigger value="list" className="flex-1">
+              <span className="flex items-center justify-center gap-2">
+                <Users className="w-4 h-4" />
+                Student List
+              </span>
+            </TabsTrigger>
+            <TabsTrigger value="analytics" className="flex-1">
+              <span className="flex items-center justify-center gap-2">
+                <BarChart3 className="w-4 h-4" />
+                Analytics
+              </span>
+            </TabsTrigger>
+          </TabsList>
 
-      {/* Tab Content */}
-      {activeTab === 'overview' && (
-        <div className="space-y-6">
-          {/* Statistics Cards */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 text-center">
-              <div className="text-3xl font-bold text-blue-600 dark:text-blue-400 mb-1">
-                {summaryStats.total}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Total Students</div>
-            </div>
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 text-center">
-              <div className="text-3xl font-bold text-green-600 dark:text-green-400 mb-1">
-                {summaryStats.active}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Active Students</div>
-            </div>
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 text-center">
-              <div className="text-3xl font-bold text-orange-600 dark:text-orange-400 mb-1">
-                {summaryStats.recentAdmissions}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">New This Month</div>
-            </div>
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 text-center">
-              <div className="text-3xl font-bold text-purple-600 dark:text-purple-400 mb-1">
-                {availableGrades.length}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-400">Grade Levels</div>
-            </div>
-          </div>
-
-          {/* Quick Actions */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h3>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              {canCreateStudent && (
-                <Button
-                  variant="outline"
-                  className="h-20 flex-col"
-                  onClick={() => handleDemoAction('create_student')}
-                >
-                  <Plus className="w-6 h-6 mb-2" />
-                  Add Student
-                </Button>
-              )}
-              
-              <Button
-                variant="outline"
-                className="h-20 flex-col"
-                onClick={() => handleDemoAction('import_students')}
-              >
-                <FileText className="w-6 h-6 mb-2" />
-                Bulk Import
-              </Button>
-              
-              {canExportData && (
-                <Button
-                  variant="outline"
-                  className="h-20 flex-col"
-                  onClick={() => handleDemoAction('generate_reports')}
-                >
-                  <BarChart3 className="w-6 h-6 mb-2" />
-                  Generate Reports
-                </Button>
-              )}
-              
-              <Button
-                variant="outline"
-                className="h-20 flex-col"
-                onClick={() => handleDemoAction('manage_grades')}
-              >
-                <BookOpen className="w-6 h-6 mb-2" />
-                Manage Grades
-              </Button>
-            </div>
-          </div>
-
-          {/* Feature Preview Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
-            {/* Core Learning System Features */}
-            <FeatureCard icon={Users} title="Student Profiles" description="Comprehensive student information management" color="blue" />
-            <FeatureCard icon={BookOpen} title="Student Progress" description="Track academic progress and performance" color="green" />
-            <FeatureCard icon={Award} title="Learning Achievements" description="Recognize and track student accomplishments" color="yellow" />
-            <FeatureCard icon={CreditCard} title="License Management" description="Manage assigned learning licenses" color="purple" />
-            <FeatureCard icon={BookOpen} title="Programs & Subjects" description="View enrolled programs and subjects" color="indigo" />
-            <FeatureCard icon={MapPin} title="Branch & Grade" description="Student's assigned branch and grade level" color="orange" />
-            <FeatureCard icon={Users} title="Class & Sections" description="Manage class and section assignments" color="teal" />
-            <FeatureCard icon={UserCheck} title="Assigned Teachers" description="View teachers assigned to student's classes" color="pink" />
-          </div>
-        </div>
-      )}
-
-      {activeTab === 'list' && (
-        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-          {/* Filters */}
-          <div className="flex flex-col lg:flex-row gap-4 mb-6">
-            <div className="flex-1">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
-                <Input
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  placeholder="Search students by name, email, or student code..."
-                  className="pl-10"
-                />
-              </div>
-            </div>
-            
-            <div className="flex gap-4">
-              {availableGrades.length > 0 && (
-                <Select
-                  value={filterGrade}
-                  onChange={(value) => setFilterGrade(value)}
-                  options={[
-                    { value: 'all', label: 'All Grades' },
-                    ...availableGrades.map(grade => ({ value: grade, label: `Grade ${grade}` }))
-                  ]}
-                  className="w-32"
-                />
-              )}
-              
-              {availableSchools.length > 0 && (
-                <Select
-                  value={filterSchool}
-                  onChange={(value) => setFilterSchool(value)}
-                  options={[
-                    { value: 'all', label: 'All Schools' },
-                    ...availableSchools.map(s => ({ value: s.id, label: s.name }))
-                  ]}
-                  className="w-48"
-                />
-              )}
-              
-              <Select
-                value={filterStatus}
-                onChange={(value) => setFilterStatus(value as 'all' | 'active' | 'inactive')}
-                options={[
-                  { value: 'all', label: 'All Status' },
-                  { value: 'active', label: 'Active Only' },
-                  { value: 'inactive', label: 'Inactive Only' }
-                ]}
-                className="w-32"
-              />
-            </div>
-          </div>
-
-          {/* Bulk Actions */}
-          {selectedStudents.length > 0 && (
-            <div className="mb-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg border">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-700 dark:text-gray-300">
-                  {selectedStudents.length} student{selectedStudents.length !== 1 ? 's' : ''} selected
-                </span>
-                <div className="flex gap-2">
-                  {canModifyStudent && (
-                    <>
-                      <Button size="sm" variant="outline" onClick={() => handleBulkAction('activate')}>
-                        <UserCheck className="w-4 h-4 mr-1" />
-                        Activate
-                      </Button>
-                      <Button size="sm" variant="outline" onClick={() => handleBulkAction('transfer')}>
-                        <MapPin className="w-4 h-4 mr-1" />
-                        Transfer
-                      </Button>
-                    </>
-                  )}
-                  {canExportData && (
-                    <Button size="sm" variant="outline" onClick={() => handleBulkAction('export')}>
-                      <FileText className="w-4 h-4 mr-1" />
-                      Export
-                    </Button>
-                  )}
+          {/* Tab Content */}
+          <TabsContent value="overview">
+            <div className="space-y-6">
+              {/* Statistics Cards */}
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 text-center">
+                  <div className="text-3xl font-bold text-blue-600 dark:text-blue-400 mb-1">
+                    {summaryStats.total}
+                  </div>
+                  <div className="text-sm text-gray-600 dark:text-gray-400">Total Students</div>
+                </div>
+                <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 text-center">
+                  <div className="text-3xl font-bold text-green-600 dark:text-green-400 mb-1">
+                    {summaryStats.active}
+                  </div>
+                  <div className="text-sm text-gray-600 dark:text-gray-400">Active Students</div>
+                </div>
+                <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 text-center">
+                  <div className="text-3xl font-bold text-orange-600 dark:text-orange-400 mb-1">
+                    {summaryStats.recentAdmissions}
+                  </div>
+                  <div className="text-sm text-gray-600 dark:text-gray-400">New This Month</div>
+                </div>
+                <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 text-center">
+                  <div className="text-3xl font-bold text-purple-600 dark:text-purple-400 mb-1">
+                    {availableGrades.length}
+                  </div>
+                  <div className="text-sm text-gray-600 dark:text-gray-400">Grade Levels</div>
                 </div>
               </div>
-            </div>
-          )}
 
-          {/* Students Table */}
-          {isLoadingStudents ? (
-            <div className="flex items-center justify-center p-8">
-              <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
-              <span className="ml-2 text-gray-600 dark:text-gray-400">Loading students...</span>
-            </div>
-          ) : studentsError ? (
-            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg p-4">
-              <div className="flex items-center">
-                <AlertTriangle className="h-5 w-5 text-red-600 dark:text-red-400 mr-2" />
-                <div>
-                  <h3 className="font-semibold text-red-800 dark:text-red-200">
-                    Error Loading Students
-                  </h3>
-                  <p className="text-sm text-red-600 dark:text-red-400 mt-1">
-                    {studentsError.message || 'Failed to load student data. Please try again.'}
-                  </p>
-                </div>
-              </div>
-            </div>
-          ) : filteredStudents.length === 0 ? (
-            <div className="text-center p-8 text-gray-500 dark:text-gray-400">
-              <GraduationCap className="h-12 w-12 mx-auto mb-4 text-gray-400" />
-              {students.length === 0 ? (
-                <>
-                  <h3 className="text-lg font-medium mb-2">No Students Found</h3>
-                  <p className="text-sm mb-4">
-                    {!canAccessAll 
-                      ? "No students found within your assigned scope." 
-                      : "No students have been added to this organization yet."
-                    }
-                  </p>
+              {/* Quick Actions */}
+              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h3>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                   {canCreateStudent && (
-                    <Button onClick={handleCreateStudent}>
-                      <Plus className="w-4 h-4 mr-2" />
-                      Add First Student
+                    <Button
+                      variant="outline"
+                      className="h-20 flex-col"
+                      onClick={() => handleDemoAction('create_student')}
+                    >
+                      <Plus className="w-6 h-6 mb-2" />
+                      Add Student
                     </Button>
                   )}
-                </>
-              ) : (
-                <>
-                  <h3 className="text-lg font-medium mb-2">No Matching Students</h3>
-                  <p className="text-sm">
-                    Try adjusting your search terms or filters to find students.
-                  </p>
-                </>
-              )}
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-gray-200 dark:border-gray-700">
-                    <th className="text-left p-3">
-                      <input
-                        type="checkbox"
-                        checked={
-                          selectedStudents.length === filteredStudents.length &&
-                          filteredStudents.length > 0
-                        }
-                        onChange={(e) => {
-                          if (e.target.checked) {
-                            setSelectedStudents(filteredStudents.map(s => s.id));
-                          } else {
-                            setSelectedStudents([]);
-                          }
-                        }}
-                        className="rounded border-gray-300 dark:border-gray-600"
-                      />
-                    </th>
-                    <th className="text-left p-3 font-medium">Student</th>
-                    <th className="text-left p-3 font-medium">Student Code</th>
-                    <th className="text-left p-3 font-medium">Grade</th>
-                    <th className="text-left p-3 font-medium">Section</th>
-                    <th className="text-left p-3 font-medium">School</th>
-                    <th className="text-left p-3 font-medium">Status</th>
-                    <th className="text-left p-3 font-medium">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredStudents.map((student) => (
-                    <tr 
-                      key={student.id} 
-                      className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50"
+
+                  <Button
+                    variant="outline"
+                    className="h-20 flex-col"
+                    onClick={() => handleDemoAction('import_students')}
+                  >
+                    <FileText className="w-6 h-6 mb-2" />
+                    Bulk Import
+                  </Button>
+
+                  {canExportData && (
+                    <Button
+                      variant="outline"
+                      className="h-20 flex-col"
+                      onClick={() => handleDemoAction('generate_reports')}
                     >
-                      <td className="p-3">
+                      <BarChart3 className="w-6 h-6 mb-2" />
+                      Generate Reports
+                    </Button>
+                  )}
+
+                  <Button
+                    variant="outline"
+                    className="h-20 flex-col"
+                    onClick={() => handleDemoAction('manage_grades')}
+                  >
+                    <BookOpen className="w-6 h-6 mb-2" />
+                    Manage Grades
+                  </Button>
+                </div>
+              </div>
+
+              {/* Feature Preview Cards */}
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+                {/* Core Learning System Features */}
+                <FeatureCard icon={Users} title="Student Profiles" description="Comprehensive student information management" color="blue" />
+                <FeatureCard icon={BookOpen} title="Student Progress" description="Track academic progress and performance" color="green" />
+                <FeatureCard icon={Award} title="Learning Achievements" description="Recognize and track student accomplishments" color="yellow" />
+                <FeatureCard icon={CreditCard} title="License Management" description="Manage assigned learning licenses" color="purple" />
+                <FeatureCard icon={BookOpen} title="Programs & Subjects" description="View enrolled programs and subjects" color="indigo" />
+                <FeatureCard icon={MapPin} title="Branch & Grade" description="Student's assigned branch and grade level" color="orange" />
+                <FeatureCard icon={Users} title="Class & Sections" description="Manage class and section assignments" color="teal" />
+                <FeatureCard icon={UserCheck} title="Assigned Teachers" description="View teachers assigned to student's classes" color="pink" />
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="list">
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+              {/* Filters */}
+              <div className="flex flex-col lg:flex-row gap-4 mb-6">
+                <div className="flex-1">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+                    <Input
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                      placeholder="Search students by name, email, or student code..."
+                      className="pl-10"
+                    />
+                  </div>
+                </div>
+
+                <div className="flex gap-4">
+                  {availableGrades.length > 0 && (
+                    <Select
+                      value={filterGrade}
+                      onChange={(value) => setFilterGrade(value)}
+                      options={[
+                        { value: 'all', label: 'All Grades' },
+                        ...availableGrades.map(grade => ({ value: grade, label: `Grade ${grade}` }))
+                      ]}
+                      className="w-32"
+                    />
+                  )}
+
+                  {availableSchools.length > 0 && (
+                    <Select
+                      value={filterSchool}
+                      onChange={(value) => setFilterSchool(value)}
+                      options={[
+                        { value: 'all', label: 'All Schools' },
+                        ...availableSchools.map(s => ({ value: s.id, label: s.name }))
+                      ]}
+                      className="w-48"
+                    />
+                  )}
+
+                  <Select
+                    value={filterStatus}
+                    onChange={(value) => setFilterStatus(value as 'all' | 'active' | 'inactive')}
+                    options={[
+                      { value: 'all', label: 'All Status' },
+                      { value: 'active', label: 'Active Only' },
+                      { value: 'inactive', label: 'Inactive Only' }
+                    ]}
+                    className="w-32"
+                  />
+                </div>
+              </div>
+
+              {/* Bulk Actions */}
+              {selectedStudents.length > 0 && (
+                <div className="mb-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg border">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-gray-700 dark:text-gray-300">
+                      {selectedStudents.length} student{selectedStudents.length !== 1 ? 's' : ''} selected
+                    </span>
+                    <div className="flex gap-2">
+                      {canModifyStudent && (
+                        <>
+                          <Button size="sm" variant="outline" onClick={() => handleBulkAction('activate')}>
+                            <UserCheck className="w-4 h-4 mr-1" />
+                            Activate
+                          </Button>
+                          <Button size="sm" variant="outline" onClick={() => handleBulkAction('transfer')}>
+                            <MapPin className="w-4 h-4 mr-1" />
+                            Transfer
+                          </Button>
+                        </>
+                      )}
+                      {canExportData && (
+                        <Button size="sm" variant="outline" onClick={() => handleBulkAction('export')}>
+                          <FileText className="w-4 h-4 mr-1" />
+                          Export
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Table */}
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                  <thead className="bg-gray-50 dark:bg-gray-700">
+                    <tr>
+                      <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         <input
                           type="checkbox"
-                          checked={selectedStudents.includes(student.id)}
-                          onChange={(e) => {
-                            if (e.target.checked) {
-                              setSelectedStudents([...selectedStudents, student.id]);
-                            } else {
-                              setSelectedStudents(selectedStudents.filter(id => id !== student.id));
-                            }
-                          }}
-                          className="rounded border-gray-300 dark:border-gray-600"
+                          checked={
+                            filteredStudents.length > 0 &&
+                            selectedStudents.length === filteredStudents.length
+                          }
+                          onChange={(e) => handleSelectAll(e.target.checked)}
+                          className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                         />
-                      </td>
-                      <td className="p-3">
-                        <div className="flex items-center gap-3">
-                          <div className="w-8 h-8 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center">
-                            <User className="w-4 h-4 text-blue-600 dark:text-blue-400" />
-                          </div>
-                          <div>
-                            <div className="font-medium text-gray-900 dark:text-white">
-                              {student.name}
-                            </div>
-                            <div className="text-sm text-gray-500 dark:text-gray-400 flex items-center gap-1">
-                              <Mail className="w-3 h-3" />
-                              {student.email}
-                            </div>
-                          </div>
-                        </div>
-                      </td>
-                      <td className="p-3">
-                        <span className="font-mono text-sm bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">
-                          {student.student_code || 'N/A'}
-                        </span>
-                      </td>
-                      <td className="p-3">
-                        <span className="px-2 py-1 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-xs rounded-full">
-                          {student.grade_level || 'N/A'}
-                        </span>
-                      </td>
-                      <td className="p-3">
-                        <span className="text-gray-700 dark:text-gray-300">
-                          {student.section || 'N/A'}
-                        </span>
-                      </td>
-                      <td className="p-3">
-                        <div className="text-sm text-gray-700 dark:text-gray-300">
-                          {student.school_name}
-                        </div>
-                      </td>
-                      <td className="p-3">
-                        <StatusBadge
-                          status={student.is_active ? 'active' : 'inactive'}
-                          variant={student.is_active ? 'success' : 'warning'}
-                        />
-                      </td>
-                      <td className="p-3">
-                        <div className="flex gap-1">
-                          <Button 
-                            size="sm" 
-                            variant="outline"
-                            onClick={() => handleViewStudent(student)}
-                            title="View Details"
-                          >
-                            <Eye className="w-4 h-4" />
-                          </Button>
-                          {canModifyStudent && (
-                            <Button 
-                              size="sm" 
-                              variant="outline"
-                              onClick={() => handleEditStudent(student)}
-                              title="Edit Student"
-                            >
-                              <Edit2 className="w-4 h-4" />
-                            </Button>
-                          )}
-                        </div>
-                      </td>
+                      </th>
+                      <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Student</th>
+                      <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Grade & Section</th>
+                      <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">School</th>
+                      <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Status</th>
+                      <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Actions</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
-      )}
+                  </thead>
+                  <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                    {isLoadingStudents && (
+                      <tr>
+                        <td colSpan={6} className="px-3 py-12 text-center text-gray-500 dark:text-gray-400">
+                          <Loader2 className="w-6 h-6 animate-spin mx-auto mb-2" />
+                          Loading students...
+                        </td>
+                      </tr>
+                    )}
 
-      {activeTab === 'analytics' && (
-        <div className="space-y-6">
-          {/* Analytics Placeholder */}
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-8 text-center">
-            <BarChart3 className="w-16 h-16 mx-auto mb-4 text-gray-400" />
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-              Student Analytics Dashboard
-            </h3>
-            <p className="text-gray-600 dark:text-gray-400 mb-4">
-              Comprehensive analytics and insights will be available here
-            </p>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-left">
-              <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
-                <h4 className="font-medium text-gray-900 dark:text-white mb-2">Enrollment Trends</h4>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Track student enrollment patterns over time</p>
-              </div>
-              <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
-                <h4 className="font-medium text-gray-900 dark:text-white mb-2">Performance Metrics</h4>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Analyze academic performance across grades</p>
-              </div>
-              <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
-                <h4 className="font-medium text-gray-900 dark:text-white mb-2">Attendance Patterns</h4>
-                <p className="text-sm text-gray-600 dark:text-gray-400">Monitor attendance rates and trends</p>
+                    {studentsError && (
+                      <tr>
+                        <td colSpan={6} className="px-3 py-12 text-center text-red-500">
+                          Failed to load students. Please try again later.
+                        </td>
+                      </tr>
+                    )}
+
+                    {!isLoadingStudents && filteredStudents.length === 0 && !studentsError && (
+                      <tr>
+                        <td colSpan={6} className="px-3 py-12 text-center text-gray-500 dark:text-gray-400">
+                          <Users className="w-10 h-10 mx-auto mb-3 text-gray-400" />
+                          <p className="font-medium">No students found</p>
+                          <p className="text-sm">Try adjusting your filters or search criteria</p>
+                        </td>
+                      </tr>
+                    )}
+
+                    {filteredStudents.map(student => (
+                      <tr key={student.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                        <td className="p-3">
+                          <input
+                            type="checkbox"
+                            checked={selectedStudents.includes(student.id)}
+                            onChange={(e) => handleSelectStudent(student.id, e.target.checked)}
+                            className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                          />
+                        </td>
+                        <td className="p-3">
+                          <div className="flex items-center gap-3">
+                            <div className="w-10 h-10 rounded-full bg-gradient-to-br from-blue-100 to-blue-200 dark:from-blue-900/30 dark:to-blue-800/30 flex items-center justify-center">
+                              <Users className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                            </div>
+                            <div>
+                              <div className="font-medium text-gray-900 dark:text-white">{student.name || 'Unnamed Student'}</div>
+                              <div className="text-sm text-gray-500 dark:text-gray-400">{student.student_code}</div>
+                              <div className="text-xs text-gray-400 dark:text-gray-500">
+                                {student.user_data?.email || 'No email provided'}
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="p-3">
+                          <div className="text-sm text-gray-700 dark:text-gray-300">
+                            Grade {student.grade_level || 'N/A'}
+                          </div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400">Section {student.section || 'N/A'}</div>
+                        </td>
+                        <td className="p-3">
+                          <div className="text-sm text-gray-700 dark:text-gray-300">
+                            {student.school_name}
+                          </div>
+                        </td>
+                        <td className="p-3">
+                          <StatusBadge
+                            status={student.is_active ? 'active' : 'inactive'}
+                            variant={student.is_active ? 'success' : 'warning'}
+                          />
+                        </td>
+                        <td className="p-3">
+                          <div className="flex gap-1">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleViewStudent(student)}
+                              title="View Details"
+                            >
+                              <Eye className="w-4 h-4" />
+                            </Button>
+                            {canModifyStudent && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => handleEditStudent(student)}
+                                title="Edit Student"
+                              >
+                                <Edit2 className="w-4 h-4" />
+                              </Button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </div>
-          </div>
-        </div>
-      )}
+          </TabsContent>
+
+          <TabsContent value="analytics">
+            <div className="space-y-6">
+              {/* Analytics Placeholder */}
+              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-8 text-center">
+                <BarChart3 className="w-16 h-16 mx-auto mb-4 text-gray-400" />
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                  Student Analytics Dashboard
+                </h3>
+                <p className="text-gray-600 dark:text-gray-400 mb-4">
+                  Comprehensive analytics and insights will be available here
+                </p>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 text-left">
+                  <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+                    <h4 className="font-medium text-gray-900 dark:text-white mb-2">Enrollment Trends</h4>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">Track student enrollment patterns over time</p>
+                  </div>
+                  <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+                    <h4 className="font-medium text-gray-900 dark:text-white mb-2">Performance Metrics</h4>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">Analyze academic performance across grades</p>
+                  </div>
+                  <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+                    <h4 className="font-medium text-gray-900 dark:text-white mb-2">Attendance Patterns</h4>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">Monitor attendance rates and trends</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </TabsContent>
+        </Tabs>
 
       {/* Development Status */}
       <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6">


### PR DESCRIPTION
## Summary
- replace the manual button-based tab navigation on the students tab with the shared Tabs components for consistent accessibility handling
- move the overview, list, and analytics sections into TabsContent panes controlled by the shared Tabs API and add a typed handler to sync tab state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc53346f80832da075be22985bd7c4