### PR TITLE
Fix password reset redirects to use reset-password route

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -54,7 +54,9 @@ export default function ForgotPasswordPage() {
 
       // CRITICAL FIX: Use the EXACT redirect URL that's configured in Supabase
       // This MUST match one of your allowed redirect URLs exactly
-      const resetRedirectUrl = 'https://ggknowledge.com/auth/reset-password';
+      const resetRedirectUrl = typeof window !== 'undefined'
+        ? `${window.location.origin}/reset-password`
+        : 'https://ggknowledge.com/reset-password';
       
       console.log('Sending reset email with redirect URL:', resetRedirectUrl);
       
@@ -128,7 +130,7 @@ export default function ForgotPasswordPage() {
 
     // TODO: Send email manually with your email service
     // For now, log the reset URL
-    console.log('Legacy reset URL:', `https://ggknowledge.com/auth/reset-password?token=${token}`);
+    console.log('Legacy reset URL:', `${typeof window !== 'undefined' ? window.location.origin : 'https://ggknowledge.com'}/reset-password?token=${token}`);
     console.log('Send this to:', userEmail);
   };
 

--- a/src/services/userCreationService.ts
+++ b/src/services/userCreationService.ts
@@ -1074,10 +1074,14 @@ export const userCreationService = {
       console.log('📧 Sending reset email to:', userData.email);
       
       // Send password reset email
+      const resetRedirectUrl = typeof window !== 'undefined'
+        ? `${window.location.origin}/reset-password`
+        : 'https://ggknowledge.com/reset-password';
+
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(
         userData.email,
         {
-          redirectTo: `${window.location.origin}/auth/reset-password`
+          redirectTo: resetRedirectUrl
         }
       );
       

--- a/supabase/migrations/20250601120000_update_reset_redirect_allowlist.sql
+++ b/supabase/migrations/20250601120000_update_reset_redirect_allowlist.sql
@@ -1,0 +1,32 @@
+-- Ensure Supabase Auth redirect allowlist uses the /reset-password route
+DO $$
+DECLARE
+  current_urls text[];
+  sanitized_urls text[];
+  target_url constant text := 'https://ggknowledge.com/reset-password';
+  legacy_url constant text := 'https://ggknowledge.com/auth/reset-password';
+BEGIN
+  SELECT additional_redirect_urls
+  INTO current_urls
+  FROM auth.config
+  LIMIT 1;
+
+  IF current_urls IS NULL THEN
+    current_urls := ARRAY[]::text[];
+  END IF;
+
+  sanitized_urls := ARRAY(
+    SELECT DISTINCT url
+    FROM unnest(current_urls) AS url
+    WHERE url IS NOT NULL
+  );
+
+  sanitized_urls := array_remove(sanitized_urls, legacy_url);
+
+  IF NOT sanitized_urls @> ARRAY[target_url] THEN
+    sanitized_urls := sanitized_urls || target_url;
+  END IF;
+
+  UPDATE auth.config
+  SET additional_redirect_urls = sanitized_urls;
+END $$;


### PR DESCRIPTION
## Summary
- update the forgot password flow to send Supabase reset emails to the existing /reset-password route
- align the admin-triggered reset email service with the same redirect target
- add a migration that updates the Supabase Auth redirect allowlist to drop the obsolete path and include the new one

## Testing
- `npm run lint` *(fails: existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e0146a25fc832d91ade3addcc69b49