### PR TITLE
Align Supabase invitation redirects with reset password page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,6 +155,7 @@ function App() {
               <Route path="/signin" element={<SignInPage />} />
               <Route path="/forgot-password" element={<ForgotPasswordPage />} />
               <Route path="/reset-password" element={<ResetPasswordPage />} />
+              <Route path="/auth/reset-password" element={<ResetPasswordPage />} />
               <Route path="/form-validation" element={<FormValidationPage />} />
               
               {/* PRESERVED: Password Change Route - Protected */}

--- a/src/services/userCreationService.ts
+++ b/src/services/userCreationService.ts
@@ -599,7 +599,7 @@ export const userCreationService = {
               company_name: await this.getCompanyName(payload.company_id),
               phone: payload.phone,
               password: payload.password, // Include if provided
-              redirect_to: `${window.location.origin}/auth/callback`,
+              redirect_to: `${window.location.origin}/reset-password`,
               send_invitation: payload.send_invitation !== false && !payload.password,
               created_by: currentUser?.email
             })
@@ -641,7 +641,7 @@ export const userCreationService = {
             company_name: await this.getCompanyName(payload.company_id),
             phone: payload.phone,
             user_metadata: userMetadata,
-            redirect_to: `${window.location.origin}/auth/callback`,
+            redirect_to: `${window.location.origin}/reset-password`,
             send_invitation: payload.send_invitation !== false && !payload.password,
             created_by: currentUser?.email
           };

--- a/supabase/functions/create-entity-users-invite/index.ts
+++ b/supabase/functions/create-entity-users-invite/index.ts
@@ -121,7 +121,7 @@ serve(async (req) => {
           body.email,
           {
             data: userMetadata,
-            redirectTo: body.redirect_to || `${Deno.env.get('PUBLIC_SITE_URL')}/auth/set-password`
+            redirectTo: body.redirect_to || `${Deno.env.get('PUBLIC_SITE_URL')}/reset-password`
           }
         )
 

--- a/supabase/functions/create-teacher-student-user/index.ts
+++ b/supabase/functions/create-teacher-student-user/index.ts
@@ -267,7 +267,7 @@ serve(async (req) => {
           body.email,
           {
             data: userMetadata,
-            redirectTo: body.redirect_to || `${Deno.env.get('PUBLIC_SITE_URL')}/auth/set-password`
+            redirectTo: body.redirect_to || `${Deno.env.get('PUBLIC_SITE_URL')}/reset-password`
           }
         )
 


### PR DESCRIPTION
## Summary
- update the client-side user creation service to send invite redirects to the reset password handler
- mirror the reset password redirect path in both Supabase edge functions so email invitations land on the same page
- expose a /auth/reset-password router alias to support legacy links hitting the reset workflow

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e014810814832d8bb60d4cab21a967