### PR TITLE
Update reset password redirects to new route

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -54,7 +54,11 @@ export default function ForgotPasswordPage() {
 
       // CRITICAL FIX: Use the EXACT redirect URL that's configured in Supabase
       // This MUST match one of your allowed redirect URLs exactly
-      const resetRedirectUrl = 'https://ggknowledge.com/auth/reset-password';
+      const siteUrl =
+        typeof window !== 'undefined'
+          ? window.location.origin
+          : import.meta.env.PUBLIC_SITE_URL || 'https://ggknowledge.com';
+      const resetRedirectUrl = `${siteUrl}/reset-password`;
       
       console.log('Sending reset email with redirect URL:', resetRedirectUrl);
       
@@ -128,7 +132,11 @@ export default function ForgotPasswordPage() {
 
     // TODO: Send email manually with your email service
     // For now, log the reset URL
-    console.log('Legacy reset URL:', `https://ggknowledge.com/auth/reset-password?token=${token}`);
+    const siteUrl =
+      typeof window !== 'undefined'
+        ? window.location.origin
+        : import.meta.env.PUBLIC_SITE_URL || 'https://ggknowledge.com';
+    console.log('Legacy reset URL:', `${siteUrl}/reset-password?token=${token}`);
     console.log('Send this to:', userEmail);
   };
 

--- a/src/services/userCreationService.ts
+++ b/src/services/userCreationService.ts
@@ -1077,7 +1077,7 @@ export const userCreationService = {
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(
         userData.email,
         {
-          redirectTo: `${window.location.origin}/auth/reset-password`
+          redirectTo: `${window.location.origin}/reset-password`
         }
       );
       


### PR DESCRIPTION
## Summary
- derive the reset password redirect URL from the current site origin (or PUBLIC_SITE_URL fallback) in the forgot password flow
- align the legacy reset logging and user creation service to reference the new /reset-password path

## Testing
- npx eslint src/app/forgot-password/page.tsx src/services/userCreationService.ts *(fails: existing lint issues in userCreationService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e01caff170832d9c29cae937bf40db