### PR TITLE
Improve Supabase error handling in student pathways

### DIFF
--- a/docs/manual-qa/student-pathways-error.md
+++ b/docs/manual-qa/student-pathways-error.md
@@ -1,0 +1,12 @@
+# Manual QA - Student Pathways Error Rendering
+
+## Scenario: Supabase returns an RLS/schema error
+1. Log in as a student user with valid Supabase credentials.
+2. In the browser devtools console, run a script (or temporarily patch the code) to force the `student_licenses` query to hit a table with RLS restrictions that the current role cannot access.
+   - Example: modify RLS policies in Supabase dashboard to deny `select` for the `student_licenses` table for the student's role.
+3. Refresh the `/student-module/pathways` page.
+
+## Expected Results
+- A toast/alert appears on the page with the exact `message` provided by Supabase (e.g. `new row violates row-level security policy for table "student_licenses"`).
+- The browser console logs `Failed to fetch student learning pathway subjects` alongside the structured Supabase error object for debugging.
+- No generic "An unexpected error occurred" placeholder is shown unless Supabase omits a `message` value.

--- a/src/app/student-module/pathways/page.tsx
+++ b/src/app/student-module/pathways/page.tsx
@@ -263,6 +263,28 @@ export default function LearningPathPage() {
     }
   );
 
+  React.useEffect(() => {
+    if (subjectsError) {
+      // Surface Supabase errors in the console to aid future debugging (e.g. RLS or schema issues)
+      console.error('Failed to fetch student learning pathway subjects', subjectsError);
+    }
+  }, [subjectsError]);
+
+  const getErrorMessage = (error: unknown): string => {
+    if (typeof error === 'string' && error.trim()) {
+      return error;
+    }
+
+    if (error && typeof error === 'object' && 'message' in error) {
+      const message = (error as { message?: unknown }).message;
+      if (typeof message === 'string' && message.trim()) {
+        return message;
+      }
+    }
+
+    return 'An unexpected error occurred. Please try again later.';
+  };
+
   const isLoading = isLoadingStudent || isLoadingSubjects;
 
   return (
@@ -299,7 +321,7 @@ export default function LearningPathPage() {
           <div>
             <p className="font-semibold">Unable to load your learning pathway</p>
             <p className="text-sm opacity-90">
-              {subjectsError instanceof Error ? subjectsError.message : 'An unexpected error occurred. Please try again later.'}
+              {getErrorMessage(subjectsError)}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- detect Supabase error messages directly on the student pathways page instead of relying on `instanceof Error`
- log structured Supabase errors in the console to support future debugging
- document a manual QA scenario to verify that real Supabase error messages reach the UI

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e03c616b74832db6490524d8ebe26d