### PR TITLE
Update admin invite redirects to production reset page

### DIFF
--- a/src/app/system-admin/admin-users/tabs/UsersTab.tsx
+++ b/src/app/system-admin/admin-users/tabs/UsersTab.tsx
@@ -193,7 +193,7 @@ async function createAdminUser(data: {
         personal_message: data.personal_message,
         send_invitation: true,
         created_by: currentUser?.email,
-        redirect_to: `${window.location.origin}/admin/set-password`
+        redirect_to: `${window.location.origin}/reset-password`
       })
     });
 

--- a/supabase/functions/create-admin-user-auth/index.ts
+++ b/supabase/functions/create-admin-user-auth/index.ts
@@ -11,6 +11,9 @@ const corsHeaders = {
   'Content-Type': 'application/json'
 }
 
+const DEFAULT_RESET_REDIRECT_URL =
+  Deno.env.get('ADMIN_RESET_REDIRECT_URL') || 'https://ggknowledge.com/reset-password'
+
 serve(async (req) => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
@@ -155,7 +158,7 @@ serve(async (req) => {
               ...userMetadata,
               personal_message: body.personal_message
             },
-            redirectTo: body.redirect_to || `${Deno.env.get('PUBLIC_SITE_URL')}/admin/set-password`
+            redirectTo: body.redirect_to || DEFAULT_RESET_REDIRECT_URL
           }
         )
 

--- a/supabase/functions/create-admin-user-complete/index.ts
+++ b/supabase/functions/create-admin-user-complete/index.ts
@@ -21,7 +21,11 @@ interface CreateUserPayload {
   send_invitation?: boolean;
   personal_message?: string;
   created_by?: string;
+  redirect_to?: string;
 }
+
+const DEFAULT_RESET_REDIRECT_URL =
+  Deno.env.get('ADMIN_RESET_REDIRECT_URL') || 'https://ggknowledge.com/reset-password'
 
 serve(async (req) => {
   // Handle CORS preflight
@@ -219,6 +223,8 @@ serve(async (req) => {
 
     // Step 4: Send invitation email if requested
     let invitationSent = false
+    const invitationRedirectUrl = body.redirect_to || DEFAULT_RESET_REDIRECT_URL
+
     if (body.send_invitation !== false) {
       try {
         const { data: inviteData, error: inviteError } = await supabaseAdmin.auth.admin.inviteUserByEmail(
@@ -228,7 +234,7 @@ serve(async (req) => {
               ...userMetadata,
               personal_message: body.personal_message
             },
-            redirectTo: `${Deno.env.get('PUBLIC_SITE_URL') || 'http://localhost:3000'}/reset-password`
+            redirectTo: invitationRedirectUrl
           }
         )
 

--- a/supabase/functions/send-admin-invite/index.ts
+++ b/supabase/functions/send-admin-invite/index.ts
@@ -11,6 +11,9 @@ const corsHeaders = {
   'Content-Type': 'application/json'
 }
 
+const DEFAULT_RESET_REDIRECT_URL =
+  Deno.env.get('ADMIN_RESET_REDIRECT_URL') || 'https://ggknowledge.com/reset-password'
+
 serve(async (req) => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
@@ -44,7 +47,7 @@ serve(async (req) => {
       type: 'recovery',
       email: body.email,
       options: {
-        redirectTo: `${Deno.env.get('SITE_URL')}/set-password`
+        redirectTo: body.redirect_to || DEFAULT_RESET_REDIRECT_URL
       }
     })
 


### PR DESCRIPTION
## Summary
- update the admin user creation UI to request reset links that point at the deployed reset-password route
- allow the create-admin-user-complete edge function to accept a redirect override while defaulting to the production reset URL
- ensure admin invite and recovery flows in edge functions always target the production reset page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e11c32c854832db0c8edef78a89d44