### PR TITLE
Adjust teacher profile navigation

### DIFF
--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -175,7 +175,7 @@ export function AdminLayout({ children, moduleKey }: AdminLayoutProps) {
     const profilePaths: Record<string, string> = {
       'entity-module': '/app/entity-module/profile',
       'system-admin': '/app/system-admin/profile',
-      'teacher-module': '/app/teacher-module/profile',
+      'teachers-module': '/app/teachers-module/profile',
       'student-module': '/app/student-module/profile',
       // Add other modules as needed
     };

--- a/src/lib/constants/moduleSubmenus.ts
+++ b/src/lib/constants/moduleSubmenus.ts
@@ -204,13 +204,6 @@ export const MODULE_SUBMENUS: SubMenuItem[] = [
     moduleKey: 'teachers-module'
   },
   {
-    id: 'teachers-profile',
-    label: 'My Profile',
-    path: '/app/teachers-module/profile',
-    icon: 'User',
-    moduleKey: 'teachers-module'
-  },
-  {
     id: 'staff-management',
     label: 'Staff Management',
     path: '/app/teachers-module/staff',


### PR DESCRIPTION
## Summary
- remove the Teacher module "My Profile" submenu entry
- ensure the profile settings dropdown points to the teachers module profile route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1417a4764832db7739a5a9977945c